### PR TITLE
Added examples folder and fixed observations

### DIFF
--- a/energym/envs/eplus_discrete.py
+++ b/energym/envs/eplus_discrete.py
@@ -170,11 +170,19 @@ class EplusDiscrete(gym.Env):
             'total_power_no_units': energy_term,
             'comfort_penalty': comfort_penalty
         }
-        return np.array(obs_dict.values), reward, done, info
+        return np.array(list(obs_dict.values())), reward, done, info
 
     def reset(self):
         t, obs, done = self.simulator.reset()
-        return np.array(obs)
+        
+        obs_dict = dict(zip(self.variables, obs))
+        
+        time_info = get_current_time_info(self.epm, t)
+        obs_dict['day'] = time_info[0]
+        obs_dict['month'] = time_info[1]
+        obs_dict['hour'] = time_info[2]
+
+        return np.array(list(obs_dict.values()))
 
     def render(self, mode='human'):
         pass

--- a/examples/test_mlflow.py
+++ b/examples/test_mlflow.py
@@ -1,0 +1,78 @@
+"""
+Example of mlflow use to automatize experimentation
+Requires: mlflow, stable-baselines
+
+$ mlflow ui
+
+Execution in localhost:5000 by default
+"""
+
+import argparse
+
+import gym
+import energym
+import mlflow
+import numpy as np
+
+from stable_baselines.common.callbacks import StopTrainingOnRewardThreshold
+
+from stable_baselines.common.policies import MlpPolicy
+from stable_baselines import PPO2
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--gamma', '-g', type=float, default=.99)
+parser.add_argument('--n_steps', '-n', type=int, default=128)
+parser.add_argument('--ent_coef', '-e', type=float, default=.01)
+parser.add_argument('--learning_rate', '-r', type=float, default=.00025)
+parser.add_argument('--vf_coef', '-v', type=float, default=.5)
+parser.add_argument('--max_grad_norm', '-m', type=float, default=.5)
+parser.add_argument('--lam', '-l', type=float, default=.95)
+parser.add_argument('--nminibatches', '-b', type=int, default=4)
+parser.add_argument('--noptepochs', '-o', type=int, default=4)
+parser.add_argument('--timesteps', '-t', type=int, default=5000)
+args = parser.parse_args()
+
+with mlflow.start_run(run_name = 'PPO2_test'):
+
+    mlflow.log_param('gamma', args.gamma)
+    mlflow.log_param('n_steps', args.n_steps)
+    mlflow.log_param('ent_coef', args.ent_coef)
+    mlflow.log_param('learning_rate', args.learning_rate)
+    mlflow.log_param('vf_coef', args.vf_coef)
+    mlflow.log_param('max_grad_norm', args.max_grad_norm)
+    mlflow.log_param('lam', args.lam)
+    mlflow.log_param('nminibatches', args.nminibatches)
+    mlflow.log_param('noptepochs', args.noptepochs)
+
+    env = gym.make('Eplus-demo-v1')
+
+    # Possible params: policy, gamma, n_steps, ent_coef, learning_rate, 
+    # vf_coef, max_grad_norm, lam, nminibatches, noptepochs...
+    # https://stable-baselines.readthedocs.io/en/master/modules/ppo2.html
+
+    model = PPO2(MlpPolicy, env, verbose=1, gamma=args.gamma, n_steps=args.n_steps, ent_coef=args.ent_coef, 
+                learning_rate=args.learning_rate, max_grad_norm=args.max_grad_norm,
+                lam=args.lam, nminibatches=args.nminibatches, noptepochs=args.noptepochs)
+    model.learn(total_timesteps=args.timesteps)
+    model.save('ppo2_eplus')
+
+    for i in range(1):
+        obs = env.reset()
+        rewards = []
+        done = False
+        current_month = 0
+    while not done:
+        a, _ = model.predict(obs)
+        obs, reward, done, info = env.step(a)
+        rewards.append(reward)
+        if info['month'] != current_month: # display results every month
+            current_month = info['month']
+            print('Reward: ', sum(rewards), info)
+    print('Episode ', i, 'Mean reward: ', np.mean(rewards), 'Cumulative reward: ', sum(rewards))
+
+    mlflow.log_metric('mean_reward', np.mean(rewards))    
+    mlflow.log_metric('sum_reward', sum(rewards))
+
+    mlflow.log_artifact('./ppo2_eplus.zip')
+
+    mlflow.end_run()

--- a/examples/test_multiobs.py
+++ b/examples/test_multiobs.py
@@ -1,0 +1,45 @@
+"""
+Example of gym wrappers use to combine multiple observations
+"""
+
+import gym
+import energym
+import numpy as np
+
+from collections import deque
+
+class MultiObsWrapper(gym.Wrapper):
+    def __init__(self, env, n=5):
+        gym.Wrapper.__init__(self, env)
+        self.n = n
+        self.history = deque([], maxlen = n)
+        shape = env.observation_space.shape
+        self.observation_space = gym.spaces.Box(low=-5e6, high=5e6, shape=((n,) + shape), dtype=np.float32)
+
+    def reset(self):
+        obs = self.env.reset()
+        for _ in range(self.n):
+            self.history.append(obs)
+        return self._get_obs()
+
+    def _get_obs(self):
+        return np.array(self.history)
+
+env = gym.make('Eplus-demo-v1')
+
+wrapped_env = MultiObsWrapper(env)
+
+for i in range(1):
+    obs = wrapped_env.reset()
+    rewards = []
+    done = False
+    current_month = 0
+    while not done:
+        a = env.action_space.sample()
+        obs, reward, done, info = wrapped_env.step(a)
+        rewards.append(reward)
+        if info['month'] != current_month: # display results every month
+            current_month = info['month']
+            print('Reward: ', sum(rewards), info)
+    print('Episode ', i, 'Mean reward: ', np.mean(rewards), 'Cumulative reward: ', sum(rewards))
+wrapped_env.close()


### PR DESCRIPTION
Added `example` directory, with some basic running scenarios:

* **test_mlflow** contains an example of _mlflow_ usage with _Energym_.
* **test_multiobs** contains an _Energym_ usage scenario with multi-observation wrappers.

Also fixed a bug that caused observations to not be captured correctly, caused by observation values not being returned as `np.array`.

Finally, the `reset` function of the environment has also been completed.

Everything has been tested to ensure that it works correctly.

Cheers! 😃 