### PR TITLE
ExpReward class

### DIFF
--- a/doc/source/pages/modules/energym.utils.rewards.ExpReward.rst
+++ b/doc/source/pages/modules/energym.utils.rewards.ExpReward.rst
@@ -1,0 +1,25 @@
+energym.utils.rewards.ExpReward
+===============================
+
+.. currentmodule:: energym.utils.rewards
+
+.. autoclass:: ExpReward
+   :members:                                                           
+   :undoc-members:               
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~ExpReward.__init__
+      ~ExpReward.calculate
+   
+   
+
+   
+   
+   

--- a/doc/source/pages/modules/energym.utils.rewards.rst
+++ b/doc/source/pages/modules/energym.utils.rewards.rst
@@ -1,4 +1,4 @@
-energym.utils.rewards
+﻿energym.utils.rewards
 =====================
 
 .. automodule:: energym.utils.rewards
@@ -19,6 +19,7 @@ energym.utils.rewards
       :toctree:                                          
       :template: custom-class-template.rst               
    
+      ExpReward
       SimpleReward
    
    

--- a/doc/source/pages/rewards.rst
+++ b/doc/source/pages/rewards.rst
@@ -11,9 +11,11 @@ reward class or defining a new one and integrate in available environments if yo
 ``SimpleReward()`` class implements an evaluation which consists in taking into account **power consumption** and **temperature comfort**. This class is used
 inner environment as an attribute.
 
+``ExpReward()`` class is the same than ``SimpleReward()`` class, but comfort penalty is exponential instead of lineal.
+
 Reward is always negative. This means that perfect reward would be 0 (perfect power consumption and perfect temperature comfort), we apply penalties in both factors.
-Notice there are two temperature comfort ranges in that class, those ranges are used rely on the specific date on the simulation. Moreover, notice also there are
+Notice there are two temperature comfort ranges in that class, those ranges are used rely on the specific date on the simulation. Moreover, notice there are
 two weights in the reward function, this allows you to adjust how important each aspect is when making a general evaluation of the environment.
 
-.. note:: *Currently, it is only available this class. However, more reward functions could be designed in the future!*
+.. note:: *Currently, it is only available these classes. However, more reward functions could be designed in the future!*
 

--- a/doc/source/pages/rewards.rst
+++ b/doc/source/pages/rewards.rst
@@ -17,5 +17,9 @@ Reward is always negative. This means that perfect reward would be 0 (perfect po
 Notice there are two temperature comfort ranges in that class, those ranges are used rely on the specific date on the simulation. Moreover, notice there are
 two weights in the reward function, this allows you to adjust how important each aspect is when making a general evaluation of the environment.
 
+By default, all environments in gym register will use SimpleReward() with default parameters. However, this configuration can be overwriting in ``gym.make()``, for example:
+::
+    env = gym.make('Eplus-discrete-stochastic-mixed-v1', reward=ExpReward(energy_weight=0.5))
+
 .. note:: *Currently, it is only available these classes. However, more reward functions could be designed in the future!*
 

--- a/energym/__init__.py
+++ b/energym/__init__.py
@@ -1,5 +1,5 @@
 from gym.envs.registration import register
-
+from energym.utils.rewards import SimpleReward
 #========================5ZoneAutoDXVAV========================#
 register(
     id='Eplus-demo-v1',
@@ -9,6 +9,7 @@ register(
         'weather_file': 'USA_PA_Pittsburgh-Allegheny.County.AP.725205_TMY3.epw',
         'variables_file': 'variablesDXVAV.cfg',
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
+        'reward': SimpleReward(),
         'env_name': 'demo-v1'
     }
 )
@@ -22,6 +23,7 @@ register(
         'variables_file': 'variablesDXVAV.cfg',
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': True,
+        'reward': SimpleReward(),
         'env_name': 'discrete-hot-v1'
     }
 )
@@ -35,6 +37,7 @@ register(
         'variables_file': 'variablesDXVAV.cfg',
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': True,
+        'reward': SimpleReward(),
         'env_name': 'discrete-mixed-v1'
     }
 )
@@ -48,6 +51,7 @@ register(
         'variables_file': 'variablesDXVAV.cfg',
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': True,
+        'reward': SimpleReward(),
         'env_name': 'discrete-cool-v1'
     }
 )
@@ -62,6 +66,7 @@ register(
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': True,
         'weather_variability': (1.0, 0.0, 0.001),
+        'reward': SimpleReward(),
         'env_name': 'discrete-stochastic-hot-v1'
     }
 )
@@ -76,6 +81,7 @@ register(
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': True,
         'weather_variability': (1.0, 0.0, 0.001),
+        'reward': SimpleReward(),
         'env_name': 'discrete-stochastic-mixed-v1'
     }
 )
@@ -90,6 +96,7 @@ register(
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': True,
         'weather_variability': (1.0, 0.0, 0.001),
+        'reward': SimpleReward(),
         'env_name': 'discrete-stochastic-cool-v1'
     }
 )
@@ -103,6 +110,7 @@ register(
         'variables_file': 'variablesDXVAV.cfg',
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': False,
+        'reward': SimpleReward(),
         'env_name': 'continuous-hot-v1'
     }
 )
@@ -116,6 +124,7 @@ register(
         'variables_file': 'variablesDXVAV.cfg',
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': False,
+        'reward': SimpleReward(),
         'env_name': 'continuous-mixed-v1'
     }
 )
@@ -129,6 +138,7 @@ register(
         'variables_file': 'variablesDXVAV.cfg',
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': False,
+        'reward': SimpleReward(),
         'env_name': 'continuous-cool-v1'
     }
 )
@@ -143,6 +153,7 @@ register(
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': False,
         'weather_variability': (1.0, 0.0, 0.001),
+        'reward': SimpleReward(),
         'env_name': 'continuous-stochastic-hot-v1'
     }
 )
@@ -157,6 +168,7 @@ register(
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': False,
         'weather_variability': (1.0, 0.0, 0.001),
+        'reward': SimpleReward(),
         'env_name': 'continuous-stochastic-mixed-v1'
     }
 )
@@ -171,6 +183,7 @@ register(
         'spaces_file': '5ZoneAutoDXVAV_spaces.cfg',
         'discrete_actions': False,
         'weather_variability': (1.0, 0.0, 0.001),
+        'reward': SimpleReward(),
         'env_name': 'continuous-stochastic-cool-v1'
     }
 )
@@ -186,6 +199,7 @@ register(
         'variables_file': 'variablesDataCenter.cfg',
         'spaces_file': '2ZoneDataCenterHVAC_wEconomizer_spaces.cfg',
         'discrete_actions': True,
+        'reward': SimpleReward(),
         'env_name': 'discrete-datacenter-v1'
     }
 )
@@ -199,6 +213,7 @@ register(
         'variables_file': 'variablesDataCenter.cfg',
         'spaces_file': '2ZoneDataCenterHVAC_wEconomizer_spaces.cfg',
         'discrete_actions': False,
+        'reward': SimpleReward(),
         'env_name': 'continuous-datacenter-v1'
     }
 )
@@ -213,6 +228,7 @@ register(
         'spaces_file': '2ZoneDataCenterHVAC_wEconomizer_spaces.cfg',
         'discrete_actions': True,
         'weather_variability': (1.0, 0.0, 0.001),
+        'reward': SimpleReward(),
         'env_name': 'discrete-stochastic-datacenter-v1'
     }
 )
@@ -227,6 +243,7 @@ register(
         'spaces_file': '2ZoneDataCenterHVAC_wEconomizer_spaces.cfg',
         'discrete_actions': False,
         'weather_variability': (1.0, 0.0, 0.001),
+        'reward': SimpleReward(),
         'env_name': 'continuous-stochastic-datacenter-v1'
     }
 )

--- a/energym/envs/eplus_env.py
+++ b/energym/envs/eplus_env.py
@@ -18,7 +18,7 @@ from copy import deepcopy
 
 from ..utils.common import get_current_time_info, parse_variables, create_variable_weather, parse_observation_action_space, setpoints_transform
 from ..simulators import EnergyPlus
-from ..utils.rewards import SimpleReward
+from ..utils.rewards import ExpReward, SimpleReward
 from pprint import pprint
 
 
@@ -38,7 +38,7 @@ class EplusEnv(gym.Env):
         env_name='eplus-env-v1',
         discrete_actions=True,
         weather_variability=None,
-        energy_weight=0.5
+        reward = SimpleReward()
     ):
         """Environment with EnergyPlus simulator.
 
@@ -62,9 +62,6 @@ class EplusEnv(gym.Env):
             self.pkg_data_path, 'variables', variables_file)
         self.spaces_path = os.path.join(
             self.pkg_data_path, 'variables', spaces_file)
-
-        # energy weight and comfort weight (1-energy weight)
-        self.energy_weight = energy_weight
 
         self.simulator = EnergyPlus(
             env_name=env_name,
@@ -120,7 +117,7 @@ class EplusEnv(gym.Env):
             )
 
         # Reward class
-        self.cls_reward = SimpleReward(energy_weight=self.energy_weight)
+        self.cls_reward = reward
 
     def step(self, action):
         """Sends action to the environment.
@@ -230,3 +227,5 @@ class EplusEnv(gym.Env):
         """End simulation."""
 
         self.simulator.end_env()
+
+    

--- a/energym/utils/rewards.py
+++ b/energym/utils/rewards.py
@@ -1,6 +1,7 @@
 """Implementation of different types of rewards."""
 
 from datetime import datetime
+from math import exp
 
 YEAR = 2021
 
@@ -60,6 +61,72 @@ class SimpleReward():
         for temperature in temperatures:
             delta_T += 0.0 if temperature >= range_T[0] and temperature <= range_T[1] else min(
                 abs(range_T[0] - temperature), abs(temperature - range_T[1]))
+        reward_comfort = - self.lambda_temp * delta_T
+
+        # Weighted sum of both terms
+        reward = self.W_energy * reward_energy + \
+            (1.0 - self.W_energy) * reward_comfort
+        terms = {'reward_energy': reward_energy,
+                 'reward_comfort': reward_comfort}
+
+        return reward, terms
+
+
+class ExpReward():
+
+    def __init__(self,
+                 range_comfort_winter=(20.0, 23.5),
+                 range_comfort_summer=(23.0, 26.0),
+                 energy_weight=0.5,
+                 lambda_energy=1e-4,
+                 lambda_temperature=1.0
+                 ):
+        """Reward considering exponential absolute difference to temperature comfort.
+
+        .. math::
+            R = - W * lambda_E * power - (1 - W) * lambda_T * exp( (max(T - T_{low}, 0) + max(T_{up} - T, 0)) )
+
+        Args:
+            range_comfort_winter (tuple, optional): Temperature comfort range for cold season. Defaults to (20.0, 23.5).
+            range_comfort_summer (tuple, optional): Temperature comfort range fot hot season. Defaults to (23.0, 26.0).
+            energy_weight (float, optional): Weight given to the energy term. Defaults to 0.5.
+            lambda_energy (float, optional): Constant for removing dimensions from power(1/W). Defaults to 1e-4.
+            lambda_temperature (float, optional): Constant for removing dimensions from temperature(1/C). Defaults to 1.0.
+        """
+
+        # Variables
+        self.range_comfort_winter = range_comfort_winter
+        self.range_comfort_summer = range_comfort_summer
+        self.W_energy = energy_weight
+        self.lambda_energy = lambda_energy
+        self.lambda_temp = lambda_temperature
+
+        # Periods
+        self.summer_start_date = datetime(YEAR, 6, 1)
+        self.summer_final_date = datetime(YEAR, 9, 30)
+
+    def calculate(self, power, temperatures, month, day):
+        """Reward calculus.
+
+        Args:
+            power (float): Power consumption.
+            temperatures (list): Indoor temperatures (one per zone).
+            month (int): Current month.
+            day (int): Current day.
+
+        Returns:
+            float: Reward value.
+        """
+        # Energy term
+        reward_energy = - self.lambda_energy * power
+
+        # Comfort term
+        current_dt = datetime(YEAR, month, day)
+        range_T = self.range_comfort_summer if current_dt >= self.summer_start_date and current_dt <= self.summer_final_date else self.range_comfort_winter
+        delta_T = 0.0
+        for temperature in temperatures:
+            delta_T += 0.0 if temperature >= range_T[0] and temperature <= range_T[1] else exp(min(
+                abs(range_T[0] - temperature), abs(temperature - range_T[1])))
         reward_comfort = - self.lambda_temp * delta_T
 
         # Weighted sum of both terms

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(name='energym',
               'pandas',  # data analysis
               'matplotlib',  # visualization
               'stable-baselines3',  # DRL with pytorch
-              'mlflow'  # tracking ML experiments
+              'mlflow',  # tracking ML experiments
+              'tensorboard' #Log stable-baselines3 trainings
           ]
       }
       )


### PR DESCRIPTION
ExpReward is available in Energym!

## Patch Notes:

- `ExpReward()` has been designed as an alternative to `SimpleReward()`. The functionality is the same, but this new function applies exponential (exp) function to comfort penalty distance instead of a lineal function (raw distance).
- Only reward weights were determined in Energym environment constructor. Now it is possible to define an instance of reward class and apply in environment constructor directly. 
    - By default, all environments in *gym register* will use `SimpleReward()` with default parameters. However, this configuration can be overwriting in `gym.make`, for example:
            `env = gym.make('Eplus-discrete-stochastic-mixed-v1', reward=ExpReward(energy_weight=0.5))`


### Extra
- Tensorboard has been added in `setup.py` like *extras*.