### PR TITLE
A different point of view for Energym package dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
   - docker
 
 before_script:
-  - docker build -t $DOCKER_USER/energym .
+  - docker build -t $DOCKER_USER/energym --build-arg ENERGYM_EXTRAS=[DRL,test] .
   
 script:
   - docker run -it $DOCKER_USER/energym /bin/bash -c 'pytest tests -vv'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 # Base on nrel/energyplus from Nicholas Long but using 
 # Ubuntu, Python 3.6 and BCVTB
-FROM ubuntu:18.04
+ARG UBUNTU_VERSION=18.04
+FROM ubuntu:${UBUNTU_VERSION}
 
 # Arguments for EnergyPlus version (default values of version 8.6.0 if is not specified)
 ARG ENERGYPLUS_VERSION=8.6.0
 ARG ENERGYPLUS_INSTALL_VERSION=8-6-0
 ARG ENERGYPLUS_SHA=198c6a3cff
+
+# Argument for Energym extras libraries
+ARG ENERGYM_EXTRAS=[extras]
 
 ENV ENERGYPLUS_VERSION=$ENERGYPLUS_VERSION
 ENV ENERGYPLUS_TAG=v$ENERGYPLUS_VERSION
@@ -59,7 +63,7 @@ COPY energym /code/energym
 COPY tests /code/tests
 COPY examples /code/examples
 COPY check_run_times.py .
-RUN pip3 install -e .[extras]
+RUN pip3 install -e .${ENERGYM_EXTRAS}
 
 CMD ["/bin/bash"]
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,6 +10,7 @@ steps:
             'build',
             '-t', 'gcr.io/${PROJECT_ID}/energym:latest',
             '--cache-from', 'gcr.io/${PROJECT_ID}/energym:latest',
+            '--build-arg', 'ENERGYM_EXTRAS=[DRL]',
             '.'
         ]
 
@@ -21,30 +22,11 @@ steps:
   # This container is going to be public (Change command in other case)
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['iam', 'ch', 'AllUsers:objectViewer', 'gs://artifacts.${PROJECT_ID}.appspot.com']
-# - name: 'gcr.io/cloud-builders/gsutil'
-#   args: ['defacl', 'ch', '-u', 'AllUsers:R', 'gs://artifacts.${PROJECT_ID}.appspot.com']
-# - name: 'gcr.io/cloud-builders/gsutil'
-#   args: ['acl', 'ch', '-r', '-u', 'AllUsers:R', 'gs://artifacts.${PROJECT_ID}.appspot.com']
-# - name: 'gcr.io/cloud-builders/gsutil'
-#   args: ['acl', 'ch', '-u', 'AllUsers:R', 'gs://artifacts.${PROJECT_ID}.appspot.com']
-
-# GCE for instance a VM with that container uploaded
-- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-  entrypoint: 'gcloud'
-  args: [
-            'compute','instances', 'create-with-container','${_VM_NAME}',
-            '--container-image', 'gcr.io/${PROJECT_ID}/energym:latest',
-            '--zone', 'europe-west1-b',
-            '--container-privileged',
-            # '--create-disk', 'name=energymvolume,mode=rw,size=50GB,type=pd-ssd',
-            # '--container-mount-host-path', 'mode=rw,mount-path=/mnt/disks/data,host-path=/home/hapneck/',
-            '--boot-disk-size', '${_DISK_SIZE}', 
-            '--boot-disk-type', '${_DISK_TYPE}',
-            '--machine-type', '${_MACHINE_TYPE}'
-        ]
 #Other options for execute build (not container)
 options:
   diskSizeGb: '10'
   machineType: 'E2_HIGHCPU_8'
 timeout: 86400s
 images: ['gcr.io/${PROJECT_ID}/energym:latest']
+
+

--- a/doc/source/pages/installation.rst
+++ b/doc/source/pages/installation.rst
@@ -161,7 +161,7 @@ If you want to use it in a **GCE VM**, you can execute the next:
 Suppose you have this repository forked and you want to upload your own container on Google Cloud and to use it. You can use **cloudbuild.yaml** 
 with our **Dockerfile** for this purpose:
 
-.. literalinclude:: ../../../cloud/cloudbuild.yaml
+.. literalinclude:: ../../../cloudbuild.yaml
     :language: yaml
 
 This file does the next:

--- a/doc/source/pages/installation.rst
+++ b/doc/source/pages/installation.rst
@@ -25,6 +25,24 @@ Docker container
 We include a **Dockerfile** for installing all dependencies and setting
 up the image for running *energym*. 
 
+By default, Dockerfile will do `pip install -e .[extras]`, if you want to install a diffetent setup, you will have to do in root repository:
+
+.. code:: sh
+
+    $ docker build -t <tag_name> --build-arg ENERGYM_EXTRAS=[<setup_tag(s)>] .
+
+For example, if you want a container with only documentation libaries and testing:
+
+.. code:: sh
+
+    $ docker build -t example1/energym:latest --build-arg ENERGYM_EXTRAS=[doc,test] .
+
+On the other hand, if you don't want any extra library, it's neccesary to write an empty value like this:
+
+.. code:: sh
+
+    $ docker build -t example1/energym:latest --build-arg ENERGYM_EXTRAS= .
+
 .. note:: If you use `Visual Studio Code <https://code.visualstudio.com/>`__, by simply opening the root directory and clicking on the pop-up button "*Reopen in container*\ ", all the dependencies will be installed automatically and you will be able to run *energym* in an isolated environment.
 
 *******************
@@ -71,8 +89,17 @@ root folder:
     $ pip install -e .
 
 Extra libraries can be installed by typing ``pip install -e .[extras]``.
-They are intended for running and analyzing DRL algorithms over *energym*,
-but they are not a requirement of the package.
+*extras* include all optional libraries which have been considered in this project such as 
+testing, visualization, Deep Reinforcement Learning, monitoring , etc.
+It's possible to select a subset of these libraries instead of 'extras' tag in which we select all optional libaries, for example:
+
+.. code:: sh
+
+    $ pip install -e .[test,doc]
+
+In order to check all our tag list, visit `setup.py <https://github.com/jajimer/energym/blob/main/setup.py>`__ in Energym root repository.
+
+In any case, they are not a requirement of the package.
 
 *******************
 Cloud Computing
@@ -134,7 +161,7 @@ If you want to use it in a **GCE VM**, you can execute the next:
 Suppose you have this repository forked and you want to upload your own container on Google Cloud and to use it. You can use **cloudbuild.yaml** 
 with our **Dockerfile** for this purpose:
 
-.. literalinclude:: ../../../cloudbuild.yaml
+.. literalinclude:: ../../../cloud/cloudbuild.yaml
     :language: yaml
 
 This file does the next:

--- a/doc/source/pages/installation.rst
+++ b/doc/source/pages/installation.rst
@@ -109,7 +109,7 @@ Cloud Computing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can run your experiments in cloud too. We are using `Google Cloud <https://cloud.google.com/>`__ in order to make it possible. Our team aim to set up
-a virtual machine in which execute our Energym container.
+a instances group (`MIG <https://cloud.google.com/compute/docs/instance-groups/getting-info-about-migs?hl=es-419>`__) in which execute our Energym container.
 
 Firstly, it is necessary that you have a Google Cloud account set up and SDK configured (auth, invoicing, project ID, etc). If you don't have this, it is recommended to check `their documentation <https://cloud.google.com/sdk/docs/install>`__.
 Secondly, It is important to have installed `Docker <https://www.docker.com/>`__ in order to be able to manage these containers in Google Cloud.
@@ -125,7 +125,7 @@ On the other hand, we are going to use specifically this services in **Google Cl
 
     - Container Registry and Artifact Registry.
     - Google Cloud builds
-    - Google Cloud Compute Engine (VM specifically)
+    - Google Cloud Compute Engine (VM and MIGs specifically)
 
 Hence, you will have to allow this services into your **Google account**.
 
@@ -143,12 +143,15 @@ If you want to use it in a **GCE VM**, you can execute the next:
 .. code:: sh
 
     $ gcloud compute instances create-with-container energym \
-    --container-image gcr.io/energym-314709/energym:latest \
-    --zone europe-west1-b \
-    --container-privileged \
-    --boot-disk-size 30GB \
-    --boot-disk-type pd-ssd  \
-    --machine-type n2-highcpu-8
+        --container-image gcr.io/energym-314709/energym \
+        --zone europe-west1-b \
+        --container-privileged \
+        --container-restart-policy never \
+        --container-stdin \
+        --container-tty \
+        --boot-disk-size 20GB \
+        --boot-disk-type pd-ssd \
+        --machine-type n2-highcpu-8
 
 .. note:: It is possible to change parameters in order to set up your own VM with your preferences (see `create-with-container <https://cloud.google.com/sdk/gcloud/reference/compute/instances/create-with-container>`__).
 
@@ -170,7 +173,6 @@ This file does the next:
     2. Build image (using cache if it's available)
     3. Push image built to Container Registry
     4. Make container public inner Container Registry.
-    5. Create GCE VM instance with that container uploaded.
 
 There is an option section at the end of the file. Do not confuse this part with the virtual machine configuration. 
 Google Cloud uses a helper VM to build everything mentioned above.
@@ -185,25 +187,69 @@ In order to execute **cloudbuild.yaml**, you have to do the next:
 .. code:: sh
 
     $ gcloud builds submit \
-      --substitutions _VM_NAME=energym,_DISK_SIZE=30GB,_DISK_TYPE=pd-ssd,_MACHINE_TYPE=n2-highcpu-8 \
-      --config ./cloudbuild.yaml .
+        --config ./cloudbuild.yaml .
 
-*Substitutions* are used in order to configure VM at the same time you build all process dinamically.
+*--substitutions* can be used in order to configure build parameters if they are needed.
 
 .. note:: "." in `--config` refers to **Dockerfile**, which is necessary to build container image (see `build-config <https://cloud.google.com/build/docs/build-config>`__).
 
 .. note:: In **cloudbuild.yaml** there is a variable named *PROJECT_ID*. However, it is not defined in substitutions. This is because it's a predetermined
           variable by Google Cloud. When build begins *"$PROJECT_ID"* is set to current value in gcloud configuration (see `substitutions-variables <https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values>`__).
 
+4. Create your VM or MIG
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-4. Init your VM
+To create a **VM** that uses this container, here there is an example:
+
+.. code:: sh
+
+    $ gcloud compute instances create-with-container energym \
+        --container-image gcr.io/energym-314709/energym \
+        --zone europe-west1-b \
+        --container-privileged \
+        --container-restart-policy never \
+        --container-stdin \
+        --container-tty \
+        --boot-disk-size 20GB \
+        --boot-disk-type pd-ssd \
+        --machine-type n2-highcpu-8
+
+.. note:: `--container-restart-policy never` it's really important for a correct functionality.
+
+.. warning:: If you decide enter in VM after create it immediately, it is possible container hasn't been created yet. 
+             You can think that is an error, Google cloud should notify this.
+
+To create a **MIG**, you need to create a machine set up **template** firstly, for example:
+
+.. code:: sh
+
+    $ gcloud compute instance-templates create-with-container energym-template \
+        --container-image gcr.io/energym-314709/energym \
+        --container-privileged \
+        --container-restart-policy never \
+        --container-stdin \
+        --container-tty \
+        --boot-disk-size 20GB \
+        --boot-disk-type pd-ssd \
+        --machine-type n2-highcpu-8
+
+Then, you can create a group-instances as large as you want:
+
+.. code:: sh
+
+    $ gcloud compute instance-groups managed create example-group \
+        --base-instance-name energym-vm \
+        --size 3 \
+        --template energym-template
+
+5. Init your VM
 ~~~~~~~~~~~~~~~~
 
 Your virtual machine is ready! To connect you can use ssh (see `gcloud-ssh <https://cloud.google.com/sdk/gcloud/reference/compute/ssh>`__):
 
 .. code:: sh
 
-    $ gcloud compute ssh ${_VM_NAME}
+    $ gcloud compute ssh energym
 
 Google Cloud use a **Container-Optimized OS** (see `documentation <https://cloud.google.com/container-optimized-os/docs>`__) in VM. This SO have docker pre-installed with energym container.
 
@@ -217,7 +263,7 @@ To use this container in our machine you only have to do:
 
 .. code:: sh
 
-    $ docker run -it gcr.io/${PROJECT_ID}/energym:latest
+    $ docker attach <container name or ID>
 
 .. image:: /_static/container2.png
   :width: 800

--- a/doc/source/pages/tests.rst
+++ b/doc/source/pages/tests.rst
@@ -18,7 +18,7 @@ These tests running under `pytest <https://docs.pytest.org/en/6.2.x/>`__ framewo
 Install Pytest
 ****************
 
-This project has already established this dependency. However, to install it independently:
+This project has already established this dependency if you have installed *extras* libreries or *test* librery specifically (see :ref:`4. Install the package`). However, to install it independently:
 
 .. code:: sh
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+pandas
 numpy
 gym
 eppy
 opyplus
-pytest

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,28 @@ setup(name='energym',
       include_package_data=True,
       extras_require={
           'extras': [
-              'pandas',  # data analysis
               'matplotlib',  # visualization
               'stable-baselines3',  # DRL with pytorch
-              'mlflow'  # tracking ML experiments
+              'mlflow',  # tracking ML experiments
+              'tensorboard', # Training logger
+              'pytest',  # Unit test repository
+              'sphinx',  # documentation
+              'sphinx-rtd-theme' #documentation theme
+          ],
+          'test': [
+              'pytest'
+          ],
+          'DRL': [
+              'stable-baselines3',
+              'mlflow',
+              'tensorboard'
+          ],
+          'doc': [
+              'sphinx',
+              'sphinx-rtd-theme'
+          ],
+          'visualization': [
+              'matplotlib'
           ]
       }
       )


### PR DESCRIPTION
This is a first proposal for Energym container management.

## Patch Notes

- Obligatory and optional libraries for Energym have been changed. Now `pandas` is in *requirements* instead of `pytest`. This is because a container image can be built without testing, and pandas is necessary for Energym Logger functionality.
- About optional packages, `extras` tag include all packages considered in this project (documentation sphinx included) and you have the possibility to select different subsets of these optional packages for Dockerfile build. Tags are:

```
setup.py extra packages
└──extras
│   │   matplotlib
│   │   stable-baselines-3
│   │   mlflow
│   │   tensorboard
│   │   pytest
│   │   sphinx
│   │   sphinx-rtd-theme
└──test
│   │   pytest
└──DRL
│   │   stable-baselines-3
│   │   mlflow
│   │   tensorboard
└──doc
│   │   sphinx
│   │   sphinx-rtd-theme
└──visualization
│   │   matplotlib
```

- Dockerfile will do `pip install -e .[extras]` by default. However, we can configure this in image built:

```
$ docker build -t example/energym:latest --build-arg ENERGYM_EXTRAS=[DRL,test] .
```

If you want "vanilla" install, use an empty value:

```
$ docker build -t example/energym:latest --build-arg ENERGYM_EXTRAS= .
```
- Travis use `DRL` and `test` tag.
- Documentation has been updated in order to clarify these new aspects.

It is a proposal, If there's something you don't agree on, we can talk about it.
Cheers!

